### PR TITLE
Update controller_stats.dart

### DIFF
--- a/lib/src/debug/models/controller_stats.dart
+++ b/lib/src/debug/models/controller_stats.dart
@@ -21,14 +21,14 @@ class ControllerStats {
     _liveInfo.remove(cinfo.id);
   }
 
-  (int, int) _equality() => (total, live);
+  (int, int) asTuple() => (total, live);
 
   @override
   bool operator ==(covariant ControllerStats other) {
     if (identical(this, other)) return true;
-    return other._equality() == _equality();
+    return other.asTuple() == asTuple();
   }
 
   @override
-  int get hashCode => _equality().hashCode;
+  int get hashCode => asTuple().hashCode;
 }


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request renames the private method `_equality` to `asTuple` in the `ControllerStats` class to improve code clarity and consistency.

* **Enhancements**:
    - Renamed the private method `_equality` to `asTuple` for better clarity and consistency.

<!-- Generated by sourcery-ai[bot]: end summary -->